### PR TITLE
Harden config writes and tighten upload/property handling

### DIFF
--- a/REVIEW.md
+++ b/REVIEW.md
@@ -1,0 +1,35 @@
+# Review notes for `s3duck-tui`
+
+## What looks good
+
+- clear package split between config / model / controller / view
+- practical feature set for an S3 TUI
+- decent handling of long-running download/upload UI updates
+- generally readable codebase
+
+## Concrete issues found
+
+1. **Config file stores secrets with executable permissions**
+   - `internal/config/config.go` wrote the JSON config with mode `0700`
+   - the file contains access keys and secret keys
+   - executable permission is unnecessary; `0600` is a better default
+
+2. **Config creation/writes ignored serialization and setup errors**
+   - `CreateEmptyConfig` and `WriteConfig` ignored some errors
+   - that can hide broken config creation or partial setup failures
+
+3. **Upload loop accumulated deferred cancels**
+   - `pkg/model/model.go` created a fresh child context per file and deferred every `cancel()`
+   - on large uploads this unnecessarily stacks deferred calls until the whole function exits
+
+4. **File-properties modal could nil-deref metadata fields**
+   - `pkg/controller/controller.go` assumed `Size` and `Etag` were always non-nil
+   - making that UI path defensive is safer when talking to varied S3-compatible backends
+
+## Changes included in PR
+
+- use `0600` for config files
+- check and report config serialization/write errors properly
+- simplify empty-config creation
+- cancel upload subcontexts immediately after each upload finishes
+- make file-properties rendering nil-safe

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -41,12 +41,14 @@ func GetHomeDir() string {
 }
 
 func (p *Params) WriteConfig() {
-
-	file, _ := json.Marshal(p.Config)
-	err := os.WriteFile(p.FileName, file, 0700)
-
+	file, err := json.Marshal(p.Config)
 	if err != nil {
-		log.Fatalf("failed to write config file: %s", filename)
+		log.Fatalf("failed to serialize config file %s: %v", p.FileName, err)
+	}
+
+	err = os.WriteFile(p.FileName, file, 0600)
+	if err != nil {
+		log.Fatalf("failed to write config file %s: %v", p.FileName, err)
 	}
 }
 
@@ -96,15 +98,19 @@ func (p *Params) DeleteConfig(i int) {
 }
 
 func CreateEmptyConfig(configFile string) {
-	err := os.MkdirAll(filepath.Dir(configFile), 0700)
-	f, err := os.Create(configFile)
+	if err := os.MkdirAll(filepath.Dir(configFile), 0700); err != nil {
+		log.Fatal(err)
+	}
+
 	ap := make([]Config, 0)
-	a, _ := json.Marshal(ap)
-	err = os.WriteFile(configFile, a, 0700)
+	a, err := json.Marshal(ap)
 	if err != nil {
 		log.Fatal(err)
 	}
-	defer f.Close()
+
+	if err := os.WriteFile(configFile, a, 0600); err != nil {
+		log.Fatal(err)
+	}
 }
 
 func NewParams() *Params {

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -1681,12 +1681,22 @@ func (c *Controller) ShowFileProperties(key string) {
 		url = fmt.Sprintf("%s/%s/%s", c.model.Cf.Url, bucketName, fullPath)
 	}
 
+	sizeText := "unknown"
+	if obj.Size != nil {
+		sizeText = humanize.IBytes(uint64(*obj.Size))
+	}
+
+	etagText := ""
+	if obj.Etag != nil {
+		etagText = *obj.Etag
+	}
+
 	text := fmt.Sprintf(
 		"[black]Name: [white]%s\n[black]Size: [white]%s\n[black]Modified: [white]%v\n[black]Etag: [white]%s\n[black]Link: [black]%s",
 		*obj.Key,
-		humanize.IBytes(uint64(*obj.Size)),
+		sizeText,
 		obj.LastModified,
-		*obj.Etag,
+		etagText,
 		url,
 	)
 

--- a/pkg/model/model.go
+++ b/pkg/model/model.go
@@ -619,13 +619,13 @@ func (m *Model) Upload(
 		}
 
 		uploadCtx, cancel := context.WithCancel(ctx)
-		defer cancel()
 
 		_, err = uploader.Upload(uploadCtx, &s3.PutObjectInput{
 			Bucket: aws.String(*bucket.Key),
 			Key:    aws.String(s3Key),
 			Body:   reader,
 		})
+		cancel()
 		fp.Close()
 
 		if err != nil {


### PR DESCRIPTION
Review summary:

- config JSON stores access keys and secret keys, so file permissions should be `0600` instead of `0700`
- config creation/writes were ignoring some serialization/setup errors
- upload created a child context per file and deferred every cancel until the whole upload completed
- file-properties rendering assumed `Size` and `Etag` were always non-nil

This PR fixes those issues by:

- writing config files with `0600`
- checking config serialization/write errors properly
- simplifying empty-config creation
- canceling each upload subcontext immediately after the upload finishes
- making file-properties rendering nil-safe

Also included: `REVIEW.md` with a concise code-review summary.